### PR TITLE
Add the possibility of passing geocoding parameters to the geocoding functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,12 @@ Geocoder.call("Toronto, ON")
 Geocoder.call({43.653226, -79.383184})
 ```
 
+You can pass options to the function that will be passed to the geocoder provider, for example:
+
+```elixir
+Geocoder.call(address: "Toronto, ON", language: "es", key: "...", ...)
+```
+
+See [here](https://developers.google.com/maps/documentation/geocoding/intro#geocoding) and [here](https://developers.google.com/maps/documentation/geocoding/intro#ReverseGeocoding) for a list of supported parameters for the default geocoder provider (`Geocoder.Provider.GoogleMaps`).
+
 And you're done! How simple was that?

--- a/lib/geocoder.ex
+++ b/lib/geocoder.ex
@@ -32,11 +32,15 @@ defmodule Geocoder do
 
   alias Geocoder.Worker
 
+  def call(opts) when is_list(opts), do: Worker.geocode(opts)
+
   def call(q, opts \\ [])
-  def call(q, opts) when is_binary(q), do: Worker.geocode(q, opts)
-  def call(q = {_,_}, opts), do: Worker.reverse_geocode(q, opts)
-  
+  def call(q, opts) when is_binary(q), do: Worker.geocode(opts ++ [address: q])
+  def call(q = {_,_}, opts), do: Worker.reverse_geocode(opts ++ [latlng: q])
+  def call(%{lat: lat, lon: lon}, opts), do: call({lat, lon}, opts)
+
   def call_list(q, opts \\ [])
-  def call_list(q = {_,_}, opts), do: Worker.reverse_geocode_list(q, opts)
-  def call_list(q, opts) when is_binary(q), do: Worker.geocode_list(q, opts)
+  def call_list(q, opts) when is_binary(q), do: Worker.geocode_list(opts ++ [address: q])
+  def call_list(q = {_,_}, opts), do: Worker.reverse_geocode_list(opts ++ [latlng: q])
+  def call_list(%{lat: lat, lon: lon}, opts), do: call_list({lat, lon}, opts)
 end

--- a/lib/geocoder/store.ex
+++ b/lib/geocoder/store.ex
@@ -3,12 +3,12 @@ defmodule Geocoder.Store do
   use Towel
 
   # Public API
-  def geocode(location) do
-    GenServer.call(name, {:geocode, location})
+  def geocode(opts) do
+    GenServer.call(name, {:geocode, opts[:address]})
   end
 
-  def reverse_geocode({lat, lon}) do
-    GenServer.call(name, {:reverse_geocode, {lat, lon}})
+  def reverse_geocode(opts) do
+    GenServer.call(name, {:reverse_geocode, opts[:latlng]})
   end
 
   def update(location) do
@@ -66,9 +66,9 @@ defmodule Geocoder.Store do
   end
 
   # Link a query to a cached value
-  def handle_cast({:link, from, %{lat: lat, lon: lon}}, {links,store,opts}) do
+  def handle_cast({:link, from, %{lat: lat, lon: lon}}, {links, store, opts}) do
     key = encode({lat, lon}, opts[:precision])
-    link = encode(from, opts[:precision])
+    link = encode(from[:address] || from[:latlng], opts[:precision])
     {:noreply, {Map.put(links, link, key), store, opts}}
   end
 


### PR DESCRIPTION
This PR adds the possibility of passing geocoding parameters to the geocoding functions. This allows setting `language`, `key` (knrz/geocoder/issues/2) and any other of the parameters that are supported by the geocoding provider (`Geocoder.Provider.GoogleMaps`):

```elixir
[:key, :address, :components, :bounds, :language, :region, :latlng, :placeid, :result_type, :location_type]
```

Missing from this PR is the support of caching by fields other than `address` and `latlng`.