### PR TITLE
Pass the configured timeout to the GenServer.call method

### DIFF
--- a/lib/geocoder/worker.ex
+++ b/lib/geocoder/worker.ex
@@ -54,7 +54,7 @@ defmodule Geocoder.Worker do
     opts = Keyword.merge(@assign_defaults, opts)
 
     function = case {opts[:stream_to], {name, q, opts}} do
-      {nil, message} -> &GenServer.call(&1, message)
+      {nil, message} -> &GenServer.call(&1, message, opts[:timeout])
       {_,   message} -> &GenServer.cast(&1, message)
     end
 


### PR DESCRIPTION
When trying to configure timeouts larger than 30s, the GenServer default timeout will trigger before the poolboy one. This PR passes the timeout to the GenServer.call method, so that larger timeouts are possible.

I was thinking that it might be better to pass `opts[:timeout]` + some time to have the poolboy timeout hit first.