### PR TITLE
OpenStreetMap provider: done.

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -4,3 +4,7 @@ config :geocoder, :worker_pool_config, [
   size: 4,
   max_overflow: 2
 ]
+
+config :geocoder, :worker, [
+  provider: Geocoder.Providers.GoogleMaps # OpenStreetMaps
+]

--- a/lib/geocoder.ex
+++ b/lib/geocoder.ex
@@ -18,7 +18,7 @@ defmodule Geocoder do
     import Supervisor.Spec
 
     children = [
-      :poolboy.child_spec(pool_name, worker_config, []),
+      :poolboy.child_spec(pool_name, worker_config, Application.get_env(:geocoder, :worker) || []),
       worker(Geocoder.Store, [store_config])
     ]
 
@@ -36,7 +36,7 @@ defmodule Geocoder do
 
   def call(q, opts \\ [])
   def call(q, opts) when is_binary(q), do: Worker.geocode(opts ++ [address: q])
-  def call(q = {_,_}, opts), do: Worker.reverse_geocode(opts ++ [latlng: q])
+  def call(q = {lat,lon}, opts), do: Worker.reverse_geocode(opts ++ [lat: lat, lon: lon, latlng: q])
   def call(%{lat: lat, lon: lon}, opts), do: call({lat, lon}, opts)
 
   def call_list(q, opts \\ [])

--- a/lib/geocoder/providers/open_street_maps.ex
+++ b/lib/geocoder/providers/open_street_maps.ex
@@ -1,0 +1,127 @@
+require IEx
+
+defmodule Geocoder.Providers.OpenStreetMaps do
+  use HTTPoison.Base
+  use Towel
+
+  # url="https://nominatim.openstreetmap.org/reverse?format=json&accept-language={{ language }}&lat={{ latitude }}&lon={{ longitude }}&zoom={{ zoom }}&addressdetails=1"
+  @endpoint "http://nominatim.openstreetmap.org/"
+  @endpath_reverse  "/reverse"
+  @endpath_search   "/search"
+  @defaults [format: "json", "accept-language": "en", "addressdetails": 1]
+
+  def geocode(opts) do
+    request(@endpath_search, extract_opts(opts))
+    |> fmap(&parse_geocode/1)
+  end
+
+  def geocode_list(opts) do
+    request_all(@endpath_search, extract_opts(opts))
+    |> fmap(fn(r) -> Enum.map(r, &parse_geocode/1) end)
+  end
+
+  def reverse_geocode(opts) do
+    request(@endpath_reverse, extract_opts(opts))
+    |> fmap(&parse_reverse_geocode/1)
+  end
+
+  def reverse_geocode_list(opts) do
+    request_all(@endpath_search, extract_opts(opts))
+    |> fmap(fn(r) -> Enum.map(r, &parse_reverse_geocode/1) end)
+  end
+
+  defp extract_opts(opts) do
+    @defaults
+    |> Keyword.merge(opts)
+    |> Keyword.put(:q, case opts |> Keyword.take([:address, :latlng]) |> Keyword.values do
+                         [{lat, lon}] -> "#{lat},#{lon}"
+                         [query] -> query
+                         _ -> nil
+                       end)
+    |> Keyword.take([:q, :key, :address, :components, :bounds, :language, :region,
+                     :latlon, :lat, :lon, :placeid, :result_type, :location_type] ++ Keyword.keys(@defaults))
+  end
+
+  defp parse_geocode(response) do
+    coords = geocode_coords(response)
+    bounds = geocode_bounds(response)
+    location = geocode_location(response)
+    %{coords | bounds: bounds, location: location}
+  end
+
+  defp parse_reverse_geocode(response) do
+    coords = geocode_coords(response)
+    bounds = geocode_bounds(response)
+    location = geocode_location(response)
+    %{coords | bounds: bounds, location: location}
+  end
+
+  defp geocode_coords(%{"lat" => lat, "lon" => lon}) do
+    [lat, lon] = [lat, lon] |> Enum.map(&String.to_float(&1))
+    %Geocoder.Coords{lat: lat, lon: lon}
+  end
+
+  defp geocode_bounds(%{"boundingbox" => bbox}) do
+    [north, south, west, east] = bbox |> Enum.map(&String.to_float(&1))
+    %Geocoder.Bounds{top: north, right: east, bottom: south, left: west}
+  end
+  defp geocode_bounds(_), do: %Geocoder.Bounds{}
+
+  # %{"address" =>
+  #      %{"city" => "Ghent", "city_district" => "Wondelgem", "country" => "Belgium",
+  #        "country_code" => "be", "county" => "Gent", "postcode" => "9032",
+  #        "road" => "Dikkelindestraat", "state" => "Flanders"},
+  #   "boundingbox" => ["51.075731", "51.0786674", "3.7063849", "3.7083991"],
+  #   "display_name" => "Dikkelindestraat, Wondelgem, Ghent, Gent, East Flanders, Flanders, 9032, Belgium",
+  #   "lat" => "51.0772661",
+  #   "licence" => "Data © OpenStreetMap contributors, ODbL 1.0. http://www.openstreetmap.org/copyright",
+  #   "lon" => "3.7074267",
+  #   "osm_id" => "45352282", "osm_type" => "way", "place_id" => "70350383"}
+  @components ~W[city city_district country country_code county postcode road state]
+  @map %{
+    "city_district" => :city,
+    "county" => :city,
+    "city" => :city,
+    "road" => :street,
+    "state" => :state,
+    "postcode" => :postal_code,
+    "country" => :country
+  }
+  defp geocode_location(%{"address" => address, "display_name" => formatted_address, "osm_type" => type}) do
+    reduce = fn {type, name}, location ->
+      Map.put(location, Map.get(@map, type), name)
+    end
+
+    location = %Geocoder.Location{country_code: address["country_code"], formatted_address: formatted_address}
+
+    address
+#    |> Enum.filter_map(type, map)
+    |> Enum.reduce(location, reduce)
+  end
+
+  defp request_all(path, params) do
+    httpoison_options = Application.get_env(:geocoder, Geocoder.Worker)[:httpoison_options] || []
+    case get(path, [], Keyword.merge(httpoison_options, params: Enum.into(params, %{}))) |> fmap(&Map.get(&1, :body)) do
+      {:ok, [list]} -> {:ok, [list]}
+      {:ok, single} -> {:ok, [single]}
+      other -> other
+    end
+  end
+
+  defp request(path, params) do
+    case request_all(path, params) do
+      {:ok, [head | _]} -> {:ok, head}
+      {:ok, [head]} -> {:ok, head}
+      {:ok, head} -> {:ok, head}
+      other -> other
+    end
+  end
+
+  defp process_url(url) do
+    @endpoint <> url
+  end
+
+  defp process_response_body(body) do
+    body |> Poison.decode!
+  end
+end

--- a/lib/geocoder/worker.ex
+++ b/lib/geocoder/worker.ex
@@ -22,7 +22,7 @@ defmodule Geocoder.Worker do
   # GenServer API
   @worker_defaults [
     store: Geocoder.Store,
-    provider: Geocoder.Providers.GoogleMaps
+    provider: Geocoder.Providers.OpenStreetMaps # GoogleMaps
   ]
   def init(conf) do
     {:ok, Keyword.merge(@worker_defaults, conf)}

--- a/test/geocoder_test.exs
+++ b/test/geocoder_test.exs
@@ -23,23 +23,30 @@ defmodule GeocoderTest do
     assert is_list(coords)
     assert Enum.count(coords) > 0
   end
-  
+
   defp assert_belgium(coords) do
-    %Geocoder.Coords{bounds: _bounds, location: location, lat: lat, lon: lon} = coords
+    %Geocoder.Coords{bounds: bounds, location: location, lat: lat, lon: lon} = coords
+
     # Bounds are not always returned
-    # assert bounds.bottom == 51.0773992
-    # assert bounds.left == 3.7073572
-    # assert bounds.right == 3.7073742
-    # assert bounds.top == 51.0774037
+    assert (nil == bounds.bottom) || (bounds.bottom |> Float.round(2) == 51.08)
+    assert (nil == bounds.left) || (bounds.left |> Float.round(2) == 3.71)
+    assert (nil == bounds.right) || (bounds.right |> Float.round(2) == 3.71)
+    assert (nil == bounds.top) || (bounds.top |> Float.round(2) == 51.08)
+
+    assert nil == location.street_number || location.street_number == "46"
     assert location.street == "Dikkelindestraat"
-    assert location.street_number == "46"
     assert location.city == "Gent"
     assert location.country == "Belgium"
-    assert location.country_code == "BE"
+    assert location.country_code |> String.upcase == "BE"
     assert location.postal_code == "9032"
-    assert location.formatted_address == "Dikkelindestraat 46, 9032 Gent, Belgium"
-    assert lat == 51.0775264
-    assert lon == 3.7073382
+    #      lhs:  "Dikkelindestraat, Wondelgem, Ghent, Gent, East Flanders, Flanders, 9032, Belgium"
+    #      rhs:  "Dikkelindestraat 46, 9032 Gent, Belgium"
+    assert location.formatted_address |> String.match?(~r/Dikkelindestraat/)
+    assert location.formatted_address |> String.match?(~r/Gent/)
+    assert location.formatted_address |> String.match?(~r/9032/)
+    assert location.formatted_address |> String.match?(~r/Belgium/)
+    assert lat |> Float.round(2) == 51.08
+    assert lon |> Float.round(2) == 3.71
   end
 
 end


### PR DESCRIPTION
Another `geo` provider: [`OpenStreetMaps`](http://wiki.openstreetmap.org/wiki/Nominatim).

I did not find any chance to switch the provider in the runtime and I did not want to mix new provider code with anything else, that’s why testing might look a bit sloppy. Basically, the new `config` option is to be set to either `Google` or `OSM` and tests are to be run. This approach is by no means CI-friendly, though.
