### PR TITLE
Correct documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Keep calm and add Geocoder to your `mix.exs` dependencies:
 
 ```elixir
 def deps do
-  [{:geocoder, "~> 0.4"}]
+  [{:geocoder, "~> 0.7"}]
 end
 ```
 
@@ -28,17 +28,17 @@ end
 Set pool configuration:
 
 ```elixir
-config :geocoder, Geocoder.Worker, [
+config :geocoder, :worker_pool_config, [
   size: 4,
   max_overflow: 2
 ]
 ```
 
-Set store configuration:
+Set provider configuration:
 
 ```elixir
-config :geocoder, Geocoder.Store, [
-  precision: 4 # the default
+config :geocoder, :worker, [
+  provider: Geocoder.Providers.GoogleMaps # is the default, or OpenStreetMaps
 ]
 ```
 

--- a/lib/geocoder/worker.ex
+++ b/lib/geocoder/worker.ex
@@ -22,7 +22,7 @@ defmodule Geocoder.Worker do
   # GenServer API
   @worker_defaults [
     store: Geocoder.Store,
-    provider: Geocoder.Providers.OpenStreetMaps # GoogleMaps
+    provider: Geocoder.Providers.GoogleMaps # or OpenStreetMaps
   ]
   def init(conf) do
     {:ok, Keyword.merge(@worker_defaults, conf)}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Geocoder.Mixfile do
   def project do
     [app: :geocoder,
      description: "A simple, efficient geocoder/reverse geocoder with a built-in cache.",
-     version: "0.6.2",
+     version: "0.7.0",
      elixir: "~> 1.2",
      package: package(),
      build_embedded: Mix.env == :prod,


### PR DESCRIPTION
Resolves https://github.com/knrz/geocoder/issues/25

* Bumps minor version because this wasn't bumped after the inclusion of county geocoding
* Made the default provider Google instead of OpenStreetMaps to reflect what's in the docs (and also because the Google provider has a superset of the functionality of the OSM one).
* Update the README about configuration parameters and versions