### PR TITLE
Add Elixir v1.4 to build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: elixir
 elixir:
   - 1.2.5
   - 1.3.0
+  - 1.4.2


### PR DESCRIPTION
Travis CI is broken still, though; see https://github.com/knrz/geocoder/pull/12#issuecomment-295731885