### PR TITLE
Remove ambiguity warnings

### DIFF
--- a/lib/geocoder.ex
+++ b/lib/geocoder.ex
@@ -18,8 +18,8 @@ defmodule Geocoder do
     import Supervisor.Spec
 
     children = [
-      :poolboy.child_spec(pool_name, worker_config, Application.get_env(:geocoder, :worker) || []),
-      worker(Geocoder.Store, [store_config])
+      :poolboy.child_spec(pool_name(), worker_config(), Application.get_env(:geocoder, :worker) || []),
+      worker(Geocoder.Store, [store_config()])
     ]
 
     options = [

--- a/lib/geocoder/store.ex
+++ b/lib/geocoder/store.ex
@@ -4,30 +4,30 @@ defmodule Geocoder.Store do
 
   # Public API
   def geocode(opts) do
-    GenServer.call(name, {:geocode, opts[:address]})
+    GenServer.call(name(), {:geocode, opts[:address]})
   end
 
   def reverse_geocode(opts) do
-    GenServer.call(name, {:reverse_geocode, opts[:latlng]})
+    GenServer.call(name(), {:reverse_geocode, opts[:latlng]})
   end
 
   def update(location) do
-    GenServer.call(name, {:update, location})
+    GenServer.call(name(), {:update, location})
   end
 
   def link(from, to) do
-    GenServer.cast(name, {:link, from, to})
+    GenServer.cast(name(), {:link, from, to})
   end
 
   def state do
-    GenServer.call(name, :state)
+    GenServer.call(name(), :state)
   end
 
   # GenServer API
   @defaults [precision: 4]
   def start_link(opts \\ []) do
     opts = Keyword.merge(@defaults, opts)
-    GenServer.start_link(__MODULE__, {%{}, %{}, opts}, [name: name])
+    GenServer.start_link(__MODULE__, {%{}, %{}, opts}, [name: name()])
   end
 
   # Fetch geocode


### PR DESCRIPTION
Removes Elixir 1.4 warnings in the style of:

```
warning: variable "pool_name" does not exist and is being expanded to "pool_name()", please use parentheses to remove the ambiguity or change the variable name
  lib/geocoder.ex:21
```