### PR TITLE
Fix OpenStreetMap provider + use it to run tests

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -6,5 +6,5 @@ config :geocoder, :worker_pool_config, [
 ]
 
 config :geocoder, :worker, [
-  provider: Geocoder.Providers.GoogleMaps # OpenStreetMaps
+  provider: Geocoder.Providers.OpenStreetMaps
 ]

--- a/lib/geocoder/providers/open_street_maps.ex
+++ b/lib/geocoder/providers/open_street_maps.ex
@@ -77,8 +77,8 @@ defmodule Geocoder.Providers.OpenStreetMaps do
   #   "osm_id" => "45352282", "osm_type" => "way", "place_id" => "70350383"}
   @components ~W[city city_district country country_code county postcode road state]
   @map %{
-    "city_district" => :city,
-    "county" => :city,
+    "house_number" => :street_number,
+    "county" => :county,
     "city" => :city,
     "road" => :street,
     "state" => :state,


### PR DESCRIPTION
Since one need a API-Key since 11. Juni 2018 for `GoogleMaps` i changed to `OpenStreetMap` provider to run tests.  
Besides, I found a little bug in the `OpenStreetMaps` provider. 