### PR TITLE
do not delete latlng key always in google provder

### DIFF
--- a/lib/geocoder/providers/google_maps.ex
+++ b/lib/geocoder/providers/google_maps.ex
@@ -42,7 +42,6 @@ defmodule Geocoder.Providers.GoogleMaps do
       {lat, lng} -> "#{lat},#{lng}"
       q -> q
     end)
-    |> Keyword.delete(:latlng)
   end
 
   defp parse_geocode(response) do


### PR DESCRIPTION
https://github.com/knrz/geocoder/compare/v0.6.2...master line 35 (now line 45 in master) of lib/geocoder/providers/google_maps.ex, used to use the old `Keyword.delete/3` which was deprecated and deleted a `:key` (second arg) for value (third arg); except when the code was updated to newer elixir which only has `Keyword.delete/2`, someone just got rid of the the third arg…. meaning instead of deleting `:latlng` when it was nil, it now always deletes the `:latlng` arg no matter what. The google provider on `1.0` does not work at all with just a `query` or with `:latlng` explicitly specified.

Please let me know if a `nil` check of the `:latlng` key is in fact necessary before dropping it as was previously the case. This change would allow `:latlng` set to default of `nil` to get through opt extraction.