### PR TITLE
use Float.parse instead of String.to_float to avoid edge cases

### DIFF
--- a/lib/geocoder/providers/open_street_maps.ex
+++ b/lib/geocoder/providers/open_street_maps.ex
@@ -82,14 +82,14 @@ defmodule Geocoder.Providers.OpenStreetMaps do
   end
 
   defp geocode_coords(%{"lat" => lat, "lon" => lon}) do
-    [lat, lon] = [lat, lon] |> Enum.map(&String.to_float(&1))
+    [lat, lon] = [lat, lon] |> Enum.map(&elem(Float.parse(&1),0))
     %Geocoder.Coords{lat: lat, lon: lon}
   end
 
   defp geocode_coords(_), do: %Geocoder.Coords{}
 
   defp geocode_bounds(%{"boundingbox" => bbox}) do
-    [north, south, west, east] = bbox |> Enum.map(&String.to_float(&1))
+    [north, south, west, east] = bbox |> Enum.map(&elem(Float.parse(&1),0))
     %Geocoder.Bounds{top: north, right: east, bottom: south, left: west}
   end
 


### PR DESCRIPTION
#60 

I'm an elixir noob, so this may be a horrible way of fixing it 🤷 - feel free to bin or ammend - grabs the first element of the tuple returned from Float.parse (rather than using String.to_float)