### PR TITLE
Add explicit module for `tap` call

### DIFF
--- a/lib/geocoder/worker.ex
+++ b/lib/geocoder/worker.ex
@@ -78,8 +78,8 @@ defmodule Geocoder.Worker do
 
   def run(function, params, false) do
     apply(params[:provider], function, [params])
-    |> tap(&params[:store].update/1)
-    |> tap(&params[:store].link(params, &1))
+    |> Monad.tap(&params[:store].update/1)
+    |> Monad.tap(&params[:store].link(params, &1))
   end
 
   def run(function, params, true) do


### PR DESCRIPTION
Since Elixir 1.12 there is a `Kernel` function called `tap/2`,
which conflicts with the `tap` from `Monad` (Towel)