### PR TITLE
Misc doc changes

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,3 +1,4 @@
+# Used by "mix format"
 [
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
 ]

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,30 @@
-/_build
-/deps
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
 erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
 *.ez
+
+# Ignore package tarball (built via "mix hex.build").
+geocoder-*.tar
+
+# Temporary files, for example, from tests.
+/tmp/
+
+# Misc.
 .DS_Store
-doc
-docs
-cover
 .tool-versions

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,8 +55,8 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project maintainers ([knrz](maintainer_knrz),
-[carpodaster](maintainer_carp)). All complaints will be reviewed and
+reported by contacting the project maintainers ([knrz][maintainer_knrz],
+[carpodaster][maintainer_carp]). All complaints will be reviewed and
 investigated and will result in a response that is deemed necessary and
 appropriate to the circumstances. The project team is obligated to maintain
 confidentiality with regard to the reporter of an incident. Further details of

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
-MIT License
+# MIT License
 
-Copyright (c) 2019 Kash Nouroozi
+Copyright (c) 2015 Kash Nouroozi
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
-Geocoder ![Build Status](https://github.com/knrz/geocoder/actions/workflows/elixir.yml/badge.svg) [![Inline docs](http://inch-ci.org/github/knrz/geocoder.svg?branch=master)](http://inch-ci.org/github/knrz/geocoder) [![Coverage Status](https://coveralls.io/repos/github/knrz/geocoder/badge.svg?branch=master)](https://coveralls.io/github/knrz/geocoder?branch=master) [![Hex pm](https://img.shields.io/hexpm/v/geocoder.svg?style=flat)](https://hex.pm/packages/geocoder)
+Geocoder
 ========
+
+[![Build Status](https://github.com/knrz/geocoder/actions/workflows/elixir.yml/badge.svg)](https://github.com/knrz/geocoder/actions/workflows/elixir.yml)
+[![Inline docs](http://inch-ci.org/github/knrz/geocoder.svg?branch=master)](http://inch-ci.org/github/knrz/geocoder)
+[![Coverage Status](https://coveralls.io/repos/github/knrz/geocoder/badge.svg?branch=master)](https://coveralls.io/github/knrz/geocoder?branch=master)
+[![Module Version](https://img.shields.io/hexpm/v/geocoder.svg)](https://hex.pm/packages/geocoder)
+[![Hex Docs](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/geocoder/)
+[![Total Download](https://img.shields.io/hexpm/dt/geocoder.svg)](https://hex.pm/packages/geocoder)
+[![License](https://img.shields.io/hexpm/l/geocoder.svg)](https://github.com/knrz/geocoder/blob/master/LICENSE)
+[![Last Updated](https://img.shields.io/github/last-commit/knrz/geocoder.svg)](https://github.com/knrz/geocoder/commits/master)
 
 A simple, efficient geocoder/reverse geocoder with a built-in cache.
 
@@ -9,11 +18,13 @@ Is it extensible? Yes.
 Installation
 ------------
 
-Keep calm and add Geocoder to your `mix.exs` dependencies:
+Keep calm and add `:geocoder` to your `mix.exs` dependencies:
 
 ```elixir
 def deps do
-  [{:geocoder, "~> 1.1"}]
+  [
+    {:geocoder, "~> 1.1"}
+  ]
 end
 ```
 
@@ -48,7 +59,7 @@ config :geocoder, :worker,
 Note that `OpenStreetMaps` (the default provider) is the only provider that does not require an API key to operate.
 All other providers require an API key that you'll need to provide.
 
-If you need to set a proxy (or any other option supported by HTTPoison.get/3):
+If you need to set a proxy (or any other option supported by `HTTPoison.get/3`):
 
 ```elixir
 config :geocoder, Geocoder.Worker, [
@@ -93,7 +104,7 @@ And you're done! How simple was that?
 Development
 -----------
 
-Right now, `geocoder` supports three providers (i.e. sources):
+Right now, `:geocoder` supports three providers (i.e. sources):
 
 * `Geocoder.Providers.GoogleMaps`
 * `Geocoder.Providers.OpenCageData`
@@ -116,6 +127,6 @@ Related & Alternative Packages
 
 ## Copyright and License
 
-Copyright (c) 2019, Kash Nouroozi.
+Copyright (c) 2015 Kash Nouroozi
 
-The source code is licensed under the [MIT License](LICENSE.md).
+The source code is licensed under the [MIT License](./LICENSE.md).

--- a/mix.exs
+++ b/mix.exs
@@ -1,16 +1,15 @@
 defmodule Geocoder.Mixfile do
   use Mix.Project
 
+  @source_url "https://github.com/knrz/geocoder"
+  @version "1.1.2"
+
   def project do
     [
       app: :geocoder,
-      description: "A simple, efficient geocoder/reverse geocoder with a built-in cache.",
-      source_url: "https://github.com/knrz/geocoder",
-      homepage_url: "https://github.com/knrz/geocoder",
-      version: "1.1.2",
+      version: @version,
       elixir: "~> 1.9",
       otp: "~> 20",
-      package: package(),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       test_coverage: [tool: ExCoveralls],
@@ -20,15 +19,21 @@ defmodule Geocoder.Mixfile do
         "coveralls.post": :test,
         "coveralls.html": :test
       ],
-      deps: deps()
+      package: package(),
+      deps: deps(),
+      docs: docs()
     ]
   end
 
   def package do
     [
+      description: "A simple, efficient geocoder/reverse geocoder with a built-in cache.",
       licenses: ["MIT"],
       maintainers: ["Kash Nouroozi", "Arjan Scherpenisse", "Michael Bianco"],
-      links: %{"GitHub" => "https://github.com/knrz/geocoder"}
+      links: %{
+        "Changelog" => "https://github.com/knrz/geocoder/releases",
+        "GitHub" => @source_url
+      }
     ]
   end
 
@@ -46,9 +51,28 @@ defmodule Geocoder.Mixfile do
       {:towel, "~> 0.2"},
       {:poolboy, "~> 1.5"},
       {:geohash, "~> 1.2"},
-      {:ex_doc, "~> 0.19", only: :dev},
+      {:ex_doc, "~> 0.24.2", only: :dev, runtime: false},
       {:inch_ex, ">= 0.0.0", only: :docs},
       {:excoveralls, "~> 0.14", only: :test}
+    ]
+  end
+
+  defp docs do
+    [
+      extras: [
+        "CODE_OF_CONDUCT.md": [title: "Code of Conduct"],
+        "LICENSE.md": [title: "License"],
+        "README.md": [title: "Overview"]
+      ],
+      groups_for_modules: [
+        Providers: ~r/^Geocoder.Providers/,
+        Structs: [Geocoder.Bounds, Geocoder.Coords, Geocoder.Location]
+      ],
+      main: "readme",
+      source_url: @source_url,
+      source_ref: "v#{@version}",
+      homepage_url: @source_url,
+      formatters: ["html"]
     ]
   end
 end


### PR DESCRIPTION
Besides other documentation changes, this commit ensures the generated
HTML doc for HexDocs.pm will become the source of truth for this Elixir
library and leverage on latest features of ExDoc.