### PR TITLE
Add support for suburbs to OpenSteetMaps

### DIFF
--- a/lib/geocoder/providers/open_street_maps.ex
+++ b/lib/geocoder/providers/open_street_maps.ex
@@ -107,6 +107,7 @@ defmodule Geocoder.Providers.OpenStreetMaps do
   #   "osm_id" => "45352282", "osm_type" => "way", "place_id" => "70350383"}
   @map %{
     "house_number" => :street_number,
+     # Australia suburbs are used instead of counties: https://github.com/knrz/geocoder/pull/71
     "suburb" => :county,
     "county" => :county,
     "city" => :city,

--- a/lib/geocoder/providers/open_street_maps.ex
+++ b/lib/geocoder/providers/open_street_maps.ex
@@ -107,6 +107,7 @@ defmodule Geocoder.Providers.OpenStreetMaps do
   #   "osm_id" => "45352282", "osm_type" => "way", "place_id" => "70350383"}
   @map %{
     "house_number" => :street_number,
+    "suburb" => :county,
     "county" => :county,
     "city" => :city,
     "road" => :street,


### PR DESCRIPTION
In Australia suburbs are used instead of counties hence the OpenStreetMaps API returns a "suburb" field instead of "county". All this PR does is maps the suburb field to county in the Geocoder.Location map. Keeping it mapping to county prevents any need for changes elsewhere or in documentation.